### PR TITLE
Fix apparent typo, align_center to aligncenter #22

### DIFF
--- a/php/Shortcodes.php
+++ b/php/Shortcodes.php
@@ -419,7 +419,7 @@ class Shortcodes {
 				$block_alignment = 'alignright';
 				break;
 			case 'center':
-				$block_alignment = 'align_center';
+				$block_alignment = 'aligncenter';
 				break;
 			case 'wide':
 				$block_alignment = 'alignwide';


### PR DESCRIPTION
#22 

## What is the desired behavior?

Using shortcode:
[wp-pic type="plugin" slug="pretty-simple-popup-builder" layout="large" scheme="scheme2" align="center" ajax="yes" ]

It should center the large layout.

## What is the actual behavior?

It does not center, the CSS I see is:
class="wp-pic-wrapper align_center large"

align_center is not in the plugin's CSS. I do see .wp-pic-wrapper.aligncenter.large and .wp-pic-wrapper.alignfull.large etc in the CSS, but it's not applied via the shortcode it seems.

## Steps to reproduce undesired behavior:

Try using the shortcode with align="center".

## Screenshots or Video

I've added custom CSS to resolve the issue:

.wp-pic-wrapper.align_center {
    text-align: center;
}

You can see my live page here, centered because of the above CSS, uncheck that CSS to view it not centered:
https://5starplugins.com/pretty-simple-popup-builder/

## Additional Comments
Hope you can fix it, I'm sure it's affecting other sites. 